### PR TITLE
Type fixes for JWPlayer amp components

### DIFF
--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -35,7 +35,7 @@ import {
   isFullscreenElement,
   removeElement,
 } from '../../../src/dom';
-import {getData, getDetail, listen} from '../../../src/event-helper';
+import {getData, listen} from '../../../src/event-helper';
 import {getMode} from '../../../src/mode';
 import {installVideoManagerForDoc} from '../../../src/service/video-manager-impl';
 import {isLayoutSizeDefined} from '../../../src/layout';
@@ -484,13 +484,13 @@ class AmpJWPlayer extends AMP.BaseElement {
 
     const data = objOrParseJson(messageData);
     const event = data['event'];
-    const value = getDetail(data);
+    const value = data['detail'];
 
     // Log any valid events
     dev().info('JWPLAYER', 'EVENT:', event || 'anon event', value || data);
 
     if (event === 'ready') {
-      this.onReadyOnce_(value);
+      value && this.onReadyOnce_(value);
       return;
     }
 


### PR DESCRIPTION
### This PR will...
Fix some typing issues with the current amp component in relation to the `gulp pr-check` task.

It leaves two in place due to complexities better solved by @zetagame 

```
extensions/amp-jwplayer/0.1/amp-jwplayer.js:487:
Originally at:
extensions/amp-jwplayer/0.1/extensions/amp-jwplayer/0.1/amp-jwplayer.js:487: ERROR - [JSC_TYPE_MISMATCH] actual parameter 1 of getDetail$$module$src$event_helper does not match formal parameter
found   : JsonObject
required: (Event|{detail: JsonObject})

extensions/amp-jwplayer/0.1/amp-jwplayer.js:493:
Originally at:
extensions/amp-jwplayer/0.1/extensions/amp-jwplayer/0.1/amp-jwplayer.js:493: ERROR - [JSC_TYPE_MISMATCH] actual parameter 1 of AmpJWPlayer$$module$extensions$amp_jwplayer$0_1$amp_jwplayer.onReadyOnce_ does not match formal parameter
found   : (JsonObject|null|string|undefined)
required: (Object|null)
```

### Why is this Pull Request needed?
Gotta pass those travis checks

### Are there any points in the code the reviewer needs to double check?
Anywhere you see a functional update for typing reasons

### Are there any Pull Requests open in other repos which need to be merged with this?
Nah

