### PR TITLE
Remove redundant muted prop

### DIFF
--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -94,9 +94,6 @@ class AmpJWPlayer extends AMP.BaseElement {
     /** @private {Object} */
     this.playlistItem_ = null;
 
-    /** @private {boolean} */
-    this.muted_ = false;
-
     /** @private {number} */
     this.duration_ = 0;
 
@@ -374,8 +371,13 @@ class AmpJWPlayer extends AMP.BaseElement {
     const {element} = this;
 
     this.playlistItem_ = {...detail.playlistItem};
-    this.muted_ = !!detail.muted;
     this.playerReadyResolver_(this.iframe_);
+
+    // Inform Video Manager that the video is pre-muted from persisted options.
+    if (detail.muted) {
+      element.dispatchCustomEvent(VideoEvents.MUTED);
+    }
+
     element.dispatchCustomEvent(VideoEvents.LOAD);
   }
 
@@ -433,7 +435,6 @@ class AmpJWPlayer extends AMP.BaseElement {
         case 'mute':
           const {mute} = detail;
           const {element} = this;
-          this.muted_ = mute;
           element.dispatchCustomEvent(mutedOrUnmutedEvent(mute));
           break;
         case 'playedRanges':

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -290,10 +290,8 @@ describes.realWin(
           const spy = env.sandbox.spy(impl.element, 'dispatchCustomEvent');
           mockMessage('mute', {mute: true});
           expect(spy).calledWith(VideoEvents.MUTED);
-          expect(impl.muted_).equals(true);
           mockMessage('mute', {mute: false});
           expect(spy).calledWith(VideoEvents.UNMUTED);
-          expect(impl.muted_).equals(false);
         });
 
         it('updates played ranges from state', () => {


### PR DESCRIPTION
Removes a muted prop from amp-jwplayer. Originally this was used to track mute for mute on auto, as well as to update state in AMP. Since it has become clear in PR feedback that this is handled by video manager, it is necessary to make a functional change to remove it.