### PR TITLE
[JW8-11060] Outstream Unit Test/Collapse-on-end and resize support

### DIFF
--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -75,6 +75,15 @@
   >
   </amp-jwplayer>
 
+  <h3>Non-Responsive, Autoplay Outstream Ad</h3>
+  <amp-jwplayer
+    data-media-id="outstream"
+    data-player-id="p4gV8jF3"
+    width="480" 
+    height="270"
+  >
+  </amp-jwplayer>
+
 
   <h3>External Controls</h3>
   <amp-jwplayer

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -287,6 +287,11 @@ class AmpJWPlayer extends AMP.BaseElement {
     this.contentBackfill_ = element.getAttribute('data-content-backfill') || '';
     this.contentRecency_ = element.getAttribute('data-content-recency') || '';
 
+    // Allow outstream playback
+    if (this.contentid_ === 'outstream') {
+      this.contentid_ = 'oi7pAMI1';
+    }
+
     installVideoManagerForDoc(this.element);
     Services.videoManagerForDoc(this.element).register(this);
   }
@@ -508,11 +513,7 @@ class AmpJWPlayer extends AMP.BaseElement {
   getSingleLineEmbed_() {
     const isDev = getMode(this.win).localDev;
     const pid = encodeURIComponent(this.playerid_);
-    let cid = encodeURIComponent(this.contentid_);
-
-    if (cid === 'outstream') {
-      cid = 'oi7pAMI1';
-    }
+    const cid = encodeURIComponent(this.contentid_);
 
     let baseUrl = `https://content.jwplatform.com/players/${cid}-${pid}.html`;
 

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -302,9 +302,7 @@ class AmpJWPlayer extends AMP.BaseElement {
 
     const url = this.getSingleLineEmbed_();
     const src = addParamsToUrl(url, queryParams);
-    const frame = disableScrollingOnIframe(
-      createFrameFor(this, src, this.element.id)
-    );
+    const frame = createFrameFor(this, src, this.element.id);
 
     addUnsafeAllowAutoplay(frame);
     disableScrollingOnIframe(frame);
@@ -445,6 +443,14 @@ class AmpJWPlayer extends AMP.BaseElement {
           const playlistItem = {...detail};
           this.playlistItem_ = playlistItem;
           this.sendCommand_('getPlayedRanges');
+          break;
+        case 'resize':
+          const {width, height} = detail;
+          Services.mutatorForDoc(this.getAmpDoc()).forceChangeSize(
+            this.element,
+            height,
+            width
+          );
           break;
         case 'time':
           const {currentTime} = detail;

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -36,9 +36,11 @@ describes.realWin(
 
     async function getjwplayer(attributes) {
       const jwp = doc.createElement('amp-jwplayer');
+
       for (const key in attributes) {
         jwp.setAttribute(key, attributes[key]);
       }
+
       const html = htmlFor(env.win.document);
 
       env.sandbox
@@ -421,6 +423,17 @@ describes.realWin(
       expect(imp.iframe_).to.be.null;
       expect(placeholder).to.not.have.display('');
     });
+
+    it('supports outstream requests', () => {
+      const attributes = {
+        'data-media-id': 'outstream',
+        'data-player-id': 'p4gV8jF3',
+      };
+      const jwp = await getjwplayer(attributes);
+      const imp = jwp.implementation_;
+
+      expect(imp.contentid_).to.equal('oi7pAMI1');
+  });
 
     it('fails if no media is specified', () => {
       return allowConsoleError(() => {


### PR DESCRIPTION
### This PR will...
- Clean up outstream contentid assignment syntax.
- Add unit test for outstream.
- Enable collapse-on-end, as well as any other resizing from jwplayer proper.