### PR TITLE
✨ ✅ [JW8-11876] Add cust-params data attribute for ads

### DIFF
--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -139,6 +139,29 @@
   >
   </amp-jwplayer>
 
+  <h3>Custom IMA Ad Params</h3>
+  <amp-jwplayer
+    data-media-id="BZ6tc0gy"
+    data-player-id="4MCKXmfU"
+    width="640"
+    height="360"
+    data-ad-cust-params='{
+      "key1": "value1",
+      "keyTest": "value2"
+    }'
+  >
+  </amp-jwplayer>
+
+  <h3>Custom VAST Ad Params</h3>
+  <amp-jwplayer
+    data-media-id="NsdRZqng"
+    data-player-id="WmASC9FK"
+    width="480"
+    height="270"
+    data-ad-cust-params='{"key1": "value1","keyTest": "value2"}'
+  >
+  </amp-jwplayer>
+
   <h3>External Controls</h3>
   <amp-jwplayer
     id="myVideo"

--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -398,6 +398,11 @@ class AmpJWPlayer extends AMP.BaseElement {
       config[attr] = configAttributes[attr];
     });
 
+    const adCustParamsJSON = element.getAttribute('data-ad-cust-params');
+    if (adCustParamsJSON) {
+      config.adCustParams = tryParseJson(adCustParamsJSON);
+    }
+
     this.postCommandMessage_('setupConfig', config);
   }
 

--- a/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/test/test-amp-jwplayer.js
@@ -422,6 +422,25 @@ describes.realWin(
         };
         expect(spy).calledWith('setupConfig', config);
       });
+
+      it('sends command with json object containing custom params', async () => {
+        const jwp = await getjwplayer({
+          'data-media-id': 'BZ6tc0gy',
+          'data-player-id': 'uoIbMPm3',
+          'data-ad-cust-params': '{"key1": "value1","keyTest": "value2"}',
+        });
+        const impl = await jwp.getImpl(false);
+        const spy = env.sandbox.stub(impl, 'postCommandMessage_');
+
+        impl.onSetup_();
+        const config = {
+          adCustParams: {
+            key1: 'value1',
+            keyTest: 'value2',
+          },
+        };
+        expect(spy).calledWith('setupConfig', config);
+      });
     });
 
     describe('createPlaceholderCallback', () => {


### PR DESCRIPTION
### This PR will...
- Add `data-ad-cust-params` attribute to past custom ad params to ad tags

### Why is this Pull Request needed?
Extend AMP Params
### Are there any points in the code the reviewer needs to double check?

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/8065

#### Addresses Issue(s):

JW8-11876

### Checklist
- [ ] Jenkins builds and unit tests are passing
- [ ] I have reviewed the automated results

<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
