### PR TITLE
[JW8-11935] Additional play event firing during pre-roll ads

### DIFF
--- a/extensions/amp-jwplayer/0.1/amp-jwplayer.js
+++ b/extensions/amp-jwplayer/0.1/amp-jwplayer.js
@@ -50,8 +50,6 @@ const JWPLAYER_EVENTS = {
   'visible': VideoEvents.VISIBILITY,
   'adImpression': VideoEvents.AD_START,
   'adComplete': VideoEvents.AD_END,
-  'adPlay': VideoEvents.PLAYING,
-  'adPause': VideoEvents.PAUSE,
 };
 
 /**


### PR DESCRIPTION
This PR will...
Prevent the duplicate play event from firing during pre-roll ads

Why is this Pull Request needed?
Are there any points in the code the reviewer needs to double check?
Are there any Pull Requests open in other repos which need to be merged with this?
Addresses Issue(s):

JW8-11935