### PR TITLE
[JW8-11900][JW8-11872] Integrate with amp-consent and add custom macros

### DIFF
--- a/examples/jwplayer.amp.html
+++ b/examples/jwplayer.amp.html
@@ -162,6 +162,29 @@
   >
   </amp-jwplayer>
 
+  <h3>Custom VAST Ad Macros</h3>
+  <amp-jwplayer
+    data-media-id="CtaIzmFs"
+    data-player-id="BjcwyK37"
+    layout="responsive"
+    width="16"
+    height="9"
+    data-ad-macro-item-test='val'
+    data-ad-macro-item-param-list='one,two,three'
+    data-config-json='{
+      "advertising": {
+        "client": "vast",
+        "schedule": [
+          {
+              "tag": "http://playertest.longtailvideo.com/pre.xml?domain=__domain__&test=__item-test__&param=__item-param-list__",
+              "offset": "pre"
+          }
+        ]
+      }
+    }'
+  >
+  </amp-jwplayer>
+
   <h3>External Controls</h3>
   <amp-jwplayer
     id="myVideo"


### PR DESCRIPTION
### This PR will...
- Add support for custom ad macros
- Integrate with amp-consent and pass consent data through embed URL

### Are there any Pull Requests open in other repos which need to be merged with this?
https://github.com/jwplayer/jwplayer-commercial/pull/8074
https://github.com/jwplayer/jwplayer-ads-shared/pull/26
<!--
# Instructions:

1. Pick a meaningful title for your pull request.
  a. Prefix the title with an emoji. (Copy-paste from the list below.)
  b. If helpful, use a short prefix (e.g. `[Project XX] Implement feature YY`).
2. Enter a description that explains why the PR is necessary, and what it does.
  a. Mention the GitHub issue being addressed by this pull request.
  b. Use keywords to auto-close linked issues during merge. (e.g. `Fixes #11111`, or `Closes #22222`)
3. For substantial changes, first file an Intent-to-Implement (I2I) issue at go.amp.dev/i2i.

# References:

- AMP code contribution docs: go.amp.dev/contribute/code
- First time setup (required for CI checks): go.amp.dev/getting-started

# Emojis for categorizing pull requests (copy-paste emoji into description):

✨ New feature
🐛 Bug fix
🔥 P0 fix
✅ Tests
❄️ Flaky tests
🚀 Performance improvements
🖍 CSS / Styling
♿ Accessibility
🌐 Internationalization
📖 Documentation
🏗 Infrastructure / Tooling / Builds / CI
⏪ Revert
♻️ Refactor
🚮 Deletion
🧪 Experimental code
-->
